### PR TITLE
Add Setup Instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ Each branch of this project represents an example:
  - [`submodules` shows how paperweight can be applied on a fork using the more traditional git submodule system](https://github.com/PaperMC/paperweight-examples/tree/submodules)
  - [`mojangapi` shows how a fork could patch arbitrary non-git directories (such as `Paper-MojangAPI`)](https://github.com/PaperMC/paperweight-examples/tree/mojangapi)
  - [`submodules-mojang` shows the same as `mojangapi`, but on the git submodules setup from `submodules`](https://github.com/PaperMC/paperweight-examples/tree/submodules-mojangapi)
+
+## Setup
+Note that when importing this project into your IDE of choice for the first time, you may experience an error such as `Could not create task ':generateDevelopmentBundle'.`. This is expected behavior - you should follow the instructions below to setup your workspace.
+
+1. Clone this repo (e.g. `git clone https://github.com/PaperMC/paperweight-examples`)
+2. Run the `applyPatches` gradle task and let it complete.
+3. Open paperweight-examples in your IDE. Your IDE's import process should now succeed. 


### PR DESCRIPTION
This PR adds instructions that fix an "error" that occurs when you attempt to import the project before running `applyPatches`. 

This is based on info gathered in PR #16, but with added context and recognizable terms for diagnosing the problem. Hopefully, the wording is better in this one and more mergeable. I was having issues getting paperweight setup myself after being told it existed in the PaperMC Discord (I was maintaining a fork of Paper using literally a fork of the Paper repo), but was having issues getting it up and running since this issue isn't super obvious. These instructions should save future folks some wasted diagnostics time, if anything.