### PR TITLE
Update v2 fork-of-forky to 1.21.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Gradle project-specific cache directory
 .gradle
+kls_database.db
 
 # Ignore Gradle build output directory
 build
@@ -16,3 +17,6 @@ build
 /fork-api
 
 .idea/
+
+# Ignore patch reject files
+*.rej

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id("io.papermc.paperweight.patcher") version "2.0.0-beta.14"
+    id("io.papermc.paperweight.patcher") version "2.0.0-beta.16"
 }
 
 paperweight {

--- a/forky-api/build.gradle.kts.patch
+++ b/forky-api/build.gradle.kts.patch
@@ -2,7 +2,7 @@
 +++ b/fork-api/build.gradle.kts
 @@ -104,17 +_,21 @@
          java {
-             srcDir(generatedApiPath)
+             srcDir(generatedDir)
              srcDir(file("../paper-api/src/main/java"))
 +            srcDir(file("../fork-api/src/main/java"))
          }

--- a/forky-server/build.gradle.kts.patch
+++ b/forky-server/build.gradle.kts.patch
@@ -1,6 +1,6 @@
 --- a/fork-server/build.gradle.kts
 +++ b/fork-server/build.gradle.kts
-@@ -30,7 +_,22 @@
+@@ -33,8 +_,22 @@
          }
      }
  
@@ -19,12 +19,12 @@
 +            outputDir = rootDirectory.dir("fork-server")
 +        }
 +    }
-+
+ 
 +    activeFork = forky
  
-     spigot {
-         buildDataRef = "3edaf46ec1eed4115ce1b18d2846cded42577e42"
-@@ -116,10 +_,14 @@
+     //updatingMinecraft {
+     //    oldPaperCommit = "f4f275519f7c1fbe9db173b7144a4fe81440e365"
+@@ -124,10 +_,14 @@
      main {
          java { srcDir("../paper-server/src/main/java") }
          resources { srcDir("../paper-server/src/main/resources") }
@@ -39,7 +39,7 @@
      }
  }
  
-@@ -143,7 +_,7 @@
+@@ -155,7 +_,7 @@
  }
  
  dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=fork.test
-version=1.21.4-R0.1-SNAPSHOT
-mcVersion=1.21.4
-forkRef=a4955854a414d436e1e378dc3626b6a86bfbbc04
+version=1.21.5-R0.1-SNAPSHOT
+mcVersion=1.21.5
+forkRef=433afcf2f7e101605535f1ab0bddef7d423d3966
 
 org.gradle.configuration-cache=true
 org.gradle.caching=true


### PR DESCRIPTION
I've updated the fork-of-a-fork example to 1.21.5. Use at your own risk.

Blocked by #31 or equivalent