### PR TITLE
Update to 1.21.11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+# Prevent Intellij IDEA from removing contextually spaced lines
+[{fork-api,fork-server}/**/*.patch]
+trim_trailing_whitespace = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id("io.papermc.paperweight.patcher") version "2.0.0-beta.18"
+    id("io.papermc.paperweight.patcher") version "2.0.0-beta.19"
 }
 
 paperweight {

--- a/fork-api/build.gradle.kts.patch
+++ b/fork-api/build.gradle.kts.patch
@@ -1,6 +1,6 @@
 --- a/paper-api/build.gradle.kts
 +++ b/paper-api/build.gradle.kts
-@@ -90,7 +_,7 @@
+@@ -91,7 +_,7 @@
      testRuntimeOnly("org.junit.platform:junit-platform-launcher")
  }
  
@@ -9,7 +9,7 @@
  idea {
      module {
          generatedSourceDirs.add(generatedDir.toFile())
-@@ -100,6 +_,18 @@
+@@ -101,6 +_,18 @@
      main {
          java {
              srcDir(generatedDir)
@@ -28,7 +28,7 @@
          }
      }
  }
-@@ -166,7 +_,7 @@
+@@ -183,7 +_,7 @@
  
  tasks.withType<Javadoc>().configureEach {
      val options = options as StandardJavadocDocletOptions
@@ -37,7 +37,7 @@
      options.use()
      options.isDocFilesSubDirs = true
      options.links(
-@@ -199,11 +_,11 @@
+@@ -216,11 +_,11 @@
      }
  
      // workaround for https://github.com/gradle/gradle/issues/4046

--- a/fork-server/build.gradle.kts.patch
+++ b/fork-server/build.gradle.kts.patch
@@ -36,7 +36,7 @@
      implementation("ca.spottedleaf:concurrentutil:0.0.8")
      implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
      implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-@@ -264,16 +_,20 @@
+@@ -264,16 +_,22 @@
      jvmArgumentProviders.add(provider)
  }
  
@@ -49,10 +49,10 @@
  }
  sourceSets {
      main {
--        java {
--            srcDir(generatedDir)
--        }
-+        java { srcDir("../paper-server/src/main/java") }
+         java {
+             srcDir(generatedDir)
++            srcDir("../paper-server/src/main/java")
+         }
 +        resources { srcDir("../paper-server/src/main/resources") }
 +    }
 +    test {

--- a/fork-server/build.gradle.kts.patch
+++ b/fork-server/build.gradle.kts.patch
@@ -1,6 +1,6 @@
 --- a/paper-server/build.gradle.kts
 +++ b/paper-server/build.gradle.kts
-@@ -26,6 +_,17 @@
+@@ -22,6 +_,17 @@
      minecraftVersion = providers.gradleProperty("mcVersion")
      gitFilePatches = false
  
@@ -17,39 +17,26 @@
 +
      spigot {
          enabled = true
-         buildDataRef = "436eac9815c211be1a2a6ca0702615f995e81c44"
-@@ -107,7 +_,20 @@
+         buildDataRef = "17f77cee7117ab9d6175f088ae8962bfd04e61a9"
+@@ -104,7 +_,9 @@
      }
  }
  
 -val log4jPlugins = sourceSets.create("log4jPlugins")
-+sourceSets {
-+    main {
-+        java { srcDir("../paper-server/src/main/java") }
-+        resources { srcDir("../paper-server/src/main/resources") }
-+    }
-+    test {
-+        java { srcDir("../paper-server/src/test/java") }
-+        resources { srcDir("../paper-server/src/test/resources") }
-+    }
-+}
-+
 +val log4jPlugins = sourceSets.create("log4jPlugins") {
 +    java { srcDir("../paper-server/src/log4jPlugins/java") }
 +}
  configurations.named(log4jPlugins.compileClasspathConfigurationName) {
      extendsFrom(configurations.compileClasspath.get())
  }
-@@ -129,7 +_,7 @@
- }
- 
+@@ -129,5 +_,5 @@
  dependencies {
 -    implementation(project(":paper-api"))
 +    implementation(project(":fork-api"))
-     implementation("ca.spottedleaf:concurrentutil:0.0.3")
+     implementation("ca.spottedleaf:concurrentutil:0.0.8")
      implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
      implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-@@ -266,7 +_,7 @@
+@@ -264,16 +_,20 @@
      jvmArgumentProviders.add(provider)
  }
  
@@ -58,3 +45,18 @@
  idea {
      module {
          generatedSourceDirs.add(generatedDir.toFile())
+     }
+ }
+ sourceSets {
+     main {
+-        java {
+-            srcDir(generatedDir)
+-        }
++        java { srcDir("../paper-server/src/main/java") }
++        resources { srcDir("../paper-server/src/main/resources") }
++    }
++    test {
++        java { srcDir("../paper-server/src/test/java") }
++        resources { srcDir("../paper-server/src/test/resources") }
+     }
+ }

--- a/fork-server/minecraft-patches/sources/net/minecraft/util/BlockUtil.java.patch
+++ b/fork-server/minecraft-patches/sources/net/minecraft/util/BlockUtil.java.patch
@@ -1,10 +1,10 @@
---- a/net/minecraft/BlockUtil.java
-+++ b/net/minecraft/BlockUtil.java
+--- a/net/minecraft/util/BlockUtil.java
++++ b/net/minecraft/util/BlockUtil.java
 @@ -16,6 +_,7 @@
      public static BlockUtil.FoundRectangle getLargestRectangleAround(
          BlockPos centerPos, Direction.Axis axis1, int max1, Direction.Axis axis2, int max2, Predicate<BlockPos> posPredicate
      ) {
-+        System.out.println("hello");
++        System.out.println("This is a test of paperweight-patcher!");
          BlockPos.MutableBlockPos mutableBlockPos = centerPos.mutable();
          Direction direction = Direction.get(Direction.AxisDirection.NEGATIVE, axis1);
          Direction opposite = direction.getOpposite();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=fork.test
-version=1.21.8-R0.1-SNAPSHOT
-mcVersion=1.21.8
-paperRef=103187750e29fd982b84b2bab114fe5af98a82e5
+version=1.21.11-R0.1-SNAPSHOT
+mcVersion=1.21.11
+paperRef=6103cc7f608badbd5e4fab95a2161cf398d5074f
 
 org.gradle.configuration-cache=true
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 group=fork.test
 version=1.21.11-R0.1-SNAPSHOT
 mcVersion=1.21.11
+apiVersion=1.21.11
 paperRef=6103cc7f608badbd5e4fab95a2161cf398d5074f
 
 org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "fork"


### PR DESCRIPTION
Thank you for the great example repository! ❤️
I updated this sample to work with Paper 1.21.11.

Specific changes:
- Updated the paperweight-patcher plugin to 2.0.0-beta.19.
- Updated the version and commit SHA specified in `gradle.properties` to 1.21.11.
- Updated `build.gradle.kts.patch` for fork-api and fork-server to match Paper 1.21.11
- The `BlockUtil.java` used in the sample has been moved from `net.minecraft` to `net.minecraft.util` so `BlockUtil.java.patch` has been updated accordingly.